### PR TITLE
build: add `typesVersions` to resolve the problem with imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netcracker/qubership-apihub-http-spec",
-  "version": "5.5.9-feature-resolve-imports",
+  "version": "5.5.9",
   "description": "",
   "keywords": [],
   "sideEffects": false,


### PR DESCRIPTION
Adding `typesVersions` helps solve an issue with imports in components that use imports from the `http-spec`.